### PR TITLE
feat: rename parameters for originator and recipients

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,15 @@ The text messages are sent using one of the configured [SMS backends](#sms-backe
 
 ### send_sms()
 
-**send_sms(_body, from_phone, to, fail_silently=False, connection=None_)**
+**send_sms(_body, originator, recipients, fail_silently=False, connection=None_)**
 
 In most cases, you can send text messages using **sms.send_sms()**.
 
-The **message**, **from_phone** and **to** parameters are required.
+The **message**, **originator** and **recipients** parameters are required.
 
 - **message**: A string.
-- **from_phone**: A string. If **None**, django-sms will use the **DEFAULT_FROM_SMS** setting.
-- **to**: A list of strings, each an phone number.
+- **originator**: A string. If **None**, django-sms will use the **DEFAULT_FROM_SMS** setting.
+- **recipients**: A list of strings, each an phone number.
 - **fail_silently**: A boolean. When it's **False**, **send_sms()** will raise an exception if an error occurs. See the [SMS backends](#sms-backends) documentation for a list of possible exceptions.
 - **connection**: The optional SMS backend to use to send the text message. If unspecified, an instance of the default backend will be used. See the documentation of [SMS backends](#sms-backends) for more details.
 
@@ -90,8 +90,8 @@ For convenience, *Message** provides a **send()** method for sending a single te
 The **Message** class is initialized with the following parameters (in the given order, if positional arguments are used). All parameters are optional and can be set at any time prior to calling the **send()** method.
 
 - **body**: The body text. This should be a plain text message.
-- **from_phone**:
-- **to**: A list or tuple of recipient phone numbers.
+- **originator**: The sender of the text message.
+- **recipients**: A list or tuple of recipient phone numbers.
 - **connection**: An SMS backend instance. Use this parameter if you want to use the same connection for multiple text messages. If omitted, a new connection is created when **send()** is called.
 
 For example:

--- a/sms/__init__.py
+++ b/sms/__init__.py
@@ -33,8 +33,8 @@ def get_connection(
 
 def send_sms(
     body: str = '',
-    from_phone: Optional[str] = None,
-    to: Union[Optional[str], Optional[List[str]]] = None,
+    originator: Optional[str] = None,
+    recipients: Union[Optional[str], Optional[List[str]]] = None,
     fail_silently: bool = False,
     connection: Optional[Type['BaseSmsBackend']] = None
 ) -> int:
@@ -44,12 +44,12 @@ def send_sms(
     Allow to to be a string, to remain compatibility with older
     django-sms<=0.0.4.
 
-    If from_phone is None, use DEFAULT_FROM_SMS setting.
+    If originator is None, use DEFAULT_FROM_SMS setting.
 
     Note: The API for this method is frozen. New code wanting to extend the
     functionality should the the Message class directly.
     """
-    if isinstance(to, str):
-        to = [to]
-    msg = Message(body, from_phone, to, connection=connection)
+    if isinstance(recipients, str):
+        recipients = [recipients]
+    msg = Message(body, originator, recipients, connection=connection)
     return msg.send(fail_silently=fail_silently)

--- a/sms/backends/console.py
+++ b/sms/backends/console.py
@@ -18,10 +18,10 @@ class SmsBackend(BaseSmsBackend):
 
     def write_message(self, message: Message) -> int:
         msg_count = 0
-        for to in message.to:
+        for recipient in message.recipients:
             msg_data = (
-                f"from: {message.from_phone}\n"
-                f"to: {to}\n"
+                f"from: {message.originator}\n"
+                f"to: {recipient}\n"
                 f"{message.body}"
             )
             self.stream.write(f'{msg_data}\n')

--- a/sms/backends/filebased.py
+++ b/sms/backends/filebased.py
@@ -51,10 +51,10 @@ class SmsBackend(BaseSmsBackend):
 
     def write_message(self, message: Message) -> int:
         msg_count = 0
-        for to in message.to:
+        for recipient in message.recipients:
             msg_data = (
-                f"from: {message.from_phone}\n"
-                f"to: {to}\n"
+                f"from: {message.originator}\n"
+                f"to: {recipient}\n"
                 f"{message.body}"
             )
             self.stream.write(f'{msg_data}\n'.encode())

--- a/sms/message.py
+++ b/sms/message.py
@@ -12,21 +12,23 @@ class Message:
     def __init__(
         self,
         body: str = '',
-        from_phone: Optional[str] = None,
-        to: Optional[List[str]] = None,
+        originator: Optional[str] = None,
+        recipients: Optional[List[str]] = None,
         connection: Optional[Type['BaseSmsBackend']] = None
     ) -> None:
         """
         Initialize a single text message (which can be sent to multiple
         recipients).
         """
-        if to:
-            if isinstance(to, str):
-                raise TypeError('"to" argument must be a list or tuple')
-            self.to = list(to)
+        if recipients:
+            if isinstance(recipients, str):
+                raise TypeError(
+                    '"recipients" argument must be a list or tuple'
+                )
+            self.recipients = recipients
         else:
-            self.to = []
-        self.from_phone = from_phone or getattr(
+            self.recipients = []
+        self.originator = originator or getattr(
             settings, 'DEFAULT_FROM_SMS', ''
         )
         self.body = body or ''
@@ -45,7 +47,7 @@ class Message:
         """
         Send the text messages return and the number of messages sent.
         """
-        if not self.to:
+        if not self.recipients:
             # Don't brother creating the network connection if there's nobody
             # to send the text message to
             return 0

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -80,12 +80,12 @@ class SmsTests(SimpleTestCase):
     @override_settings(SMS_BACKEND='sms.backends.locmem.SmsBackend')
     def test_send_sms(self) -> None:
         """
-        Test send_sms with the to specified as a string to remain compatibility
-        with django-sms<=0.0.4.
+        Test send_sms with the recipients specified as a string to remain
+        compatibility with django-sms<=0.0.4.
         """
         send_sms('Content', '0600000000', '0600000000')
         self.assertEqual(len(sms.outbox), 1)  # type: ignore
-        self.assertIsInstance(sms.outbox[0].to, list)  # type: ignore
+        self.assertIsInstance(sms.outbox[0].recipients, list)  # type: ignore
 
 
 class LocmemBackendTests(BaseSmsBackendTests, SimpleTestCase):
@@ -173,5 +173,5 @@ class FileBasedBackendTests(BaseSmsBackendTests, SimpleTestCase):
         tmp_file = os.path.join(self.tmp_dir, os.listdir(self.tmp_dir)[0])
         with open(tmp_file, 'rb') as fp:
             message = message_from_binary_file(fp)
-        self.assertEqual(message.from_phone, '+12065550100')
-        self.assertEqual(message.to, ['+441134960000'])
+        self.assertEqual(message.originator, '+12065550100')
+        self.assertEqual(message.recipients, ['+441134960000'])


### PR DESCRIPTION
 Rename parameters for `originator` (_originally `from_phone`_) and `recipients` (_originally `to`_).