### PR TITLE
feat: add post_send signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes in **django-sms** are documented below.
 
 ## [Unreleased]
+### Added
+- The **sms.signals.post_send** signal to let user code get notified by Django itself after **send()** is called on a **Message** instance.
 
 ## [0.2.0] (2021-01-21)
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
             - [In-memory backend](#in-memory-backend)
             - [Dummy backend](#dummy-backend)
         - [Defining a custom SMS backend](#defining-a-custom-sms-backend)
+    - [Signals](#signals)
 - [Acknowledgement](#acknowledgement)
 
 ## Sending SMS
@@ -199,6 +200,13 @@ This backend is not intended for use in production - it is provided as a conveni
 If you need to change how text messages are sent you can write your own SMS backend. The **SMS_BACKEND** setting in your settings file is then the Python import path for you backend class.
 
 Custom SMS backends should subclass **BaseSmsBackend** that is located in the **sms.backends.base** module. A custom SMS backend must implement the **send_messages(messages)** method. This methods receives a list of **Message** instances and returns the number of successfully delivered messages. If your backend has any concept of a persistent session or connection, you should also implement **open()** and **close()** methods. Refer to one of the existing SMS backends for a reference implementation.
+
+### Signals
+django-sms provides a set of built-in signals that let user code get notified by Django itself of certain actions. These include some useful notifications:
+
+- **sms.signals.post_send**
+
+    Sent after **send()** is called on a **Message** instance.
 
 ## Acknowledgement
 

--- a/sms/signals.py
+++ b/sms/signals.py
@@ -1,0 +1,4 @@
+from django.dispatch import Signal  # type: ignore
+
+
+post_send = Signal()


### PR DESCRIPTION
Add the **sms.signals.post_send** signal to let user code get notified by Django itself after **send()** is called on a **Message** instance.