### PR TITLE
Simplify the post_send signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes in **django-sms** are documented below.
 
 ## [Unreleased]
+### Changed
+- Simplified the attributes of the **sms.signals.post_send** signal to include the instance of the originating **Message** instead of all attributes ([#11](https://github.com/roaldnefs/django-sms/pull/11)).
 
 ## [0.3.0] (2021-01-30)
 ### Added

--- a/sms/message.py
+++ b/sms/message.py
@@ -55,12 +55,6 @@ class Message:
         connection: Type['BaseSmsBackend'] = self.get_connection(fail_silently)
         count = connection.send_messages([self])  # type: ignore
 
-        post_send.send(
-            sender=self.__class__,
-            body=self.body,
-            originator=self.originator,
-            recipients=self.recipients,
-            connection=connection
-        )
+        post_send.send(sender=self.__class__, instance=self)
 
         return count

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -191,8 +191,8 @@ class SignalTests(SimpleTestCase):
     def test_receiver_post_send_signal(self) -> None:
         """Make sure the post_send signal is called."""
         @receiver(post_send)
-        def f(body, **kwargs):
-            self.body = body
+        def f(instance, **kwargs):
+            self.body = instance.body
             self.state = True
         self.state = False
         self.body = None


### PR DESCRIPTION
Simplify the **post_send** signal by sending the instance of a **Message** object instead of all attributes as arguments.