### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes in **django-sms** are documented below.
 
 ## [Unreleased]
+
+## [0.4.0]
 ### Added
 - The **sms.backends.messagebird.SmsBackend** to send text messages using [MessageBird](https://messagebird.com/) ([#6](https://github.com/roaldnefs/django-sms/issues/6)).
 
@@ -20,7 +22,8 @@ All notable changes in **django-sms** are documented below.
 ### Added
 - This `CHANGELOG.md` file to be able to list all notable changes for each version of **django-sms**.
 
-[Unreleased]: https://github.com/roaldnefs/django-sms/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/roaldnefs/django-sms/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/roaldnefs/django-sms/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/roaldnefs/django-sms/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/roaldnefs/django-sms/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/roaldnefs/django-sms/releases/tag/v0.1.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,7 @@
 project = 'django-sms'
 copyright = '2021, Roald Nefs'
 author = 'Roald Nefs'
-release = '0.3.0'
+release = '0.4.0'
 
 extensions = ['m2r2']
 templates_path = ['_templates']

--- a/setup.py
+++ b/setup.py
@@ -14,13 +14,13 @@ def long_description() -> str:
 
     with open('CHANGELOG.md') as changelog_file:
         changelog = changelog_file.read()
-    
+
     return readme + changelog
 
 
 setup(
     name='django-sms',
-    version='0.3.0',
+    version='0.4.0',
     url="https://github.com/django-enterprise/django-sms",
     description='A Django app for sending SMS with interchangeable backends.',
     long_description=long_description(),


### PR DESCRIPTION
### Added
- The **sms.backends.messagebird.SmsBackend** to send text messages using [MessageBird](https://messagebird.com/) ([#6](https://github.com/roaldnefs/django-sms/issues/6)).

### Changed
- Simplified the attributes of the **sms.signals.post_send** signal to include the instance of the originating **Message** instead of all attributes ([#11](https://github.com/roaldnefs/django-sms/pull/11)).