### PR TITLE
Transfer parameters up to specific client constructors for twilio and messagebird

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ SMS_BACKEND = 'sms.backends.messagebird.SmsBackend'
 MESSAGEBIRD_ACCESS_KEY = 'live_redacted-messagebird-access-key'
 ```
 
+The `access_key` (overriding `MESSAGEBIRD_ACCESS_KEY`) and other optional backend keyword parameters transferred from the `get_connection()` call are passed to the `messagebird.Client` constructor.
+
 Make sure the MessageBird Python SDK is installed by running the following command:
 
 ```console
@@ -207,6 +209,8 @@ SMS_BACKEND = 'sms.backends.twilio.SmsBackend'
 TWILIO_ACCOUNT_SID = 'live_redacted-twilio-account-sid'
 TWILIO_AUTH_TOKEN = 'live_redacted-twilio-auth-token'
 ```
+
+The `username` and `password` (overriding `TWILIO_ACCOUNT_SID` and `TWILIO_AUTH_TOKEN`) and other optional backend keyword parameters transferred from the `get_connection()` call are passed to the `twilio.rest.Client` constructor.
 
 Make sure the Twilio Python SDK is installed by running the following command:
 

--- a/sms/backends/messagebird.py
+++ b/sms/backends/messagebird.py
@@ -28,7 +28,9 @@ class SmsBackend(BaseSmsBackend):
                 "another SMS backend."
             )
 
-        access_key: Optional[str] = getattr(settings, 'MESSAGEBIRD_ACCESS_KEY')
+        access_key: Optional[str] = kwargs.pop(
+            'access_key', getattr(settings, 'MESSAGEBIRD_ACCESS_KEY')
+        )
         if not access_key and not self.fail_silently:
             raise ImproperlyConfigured(
                 "You're using the SMS backend "
@@ -38,7 +40,7 @@ class SmsBackend(BaseSmsBackend):
 
         self.client = None
         if HAS_MESSAGEBIRD:
-            self.client = messagebird.Client(access_key)
+            self.client = messagebird.Client(access_key, **kwargs)
 
     def send_messages(self, messages: List[Message]) -> int:
         if not self.client:

--- a/sms/backends/twilio.py
+++ b/sms/backends/twilio.py
@@ -28,7 +28,9 @@ class SmsBackend(BaseSmsBackend):
                 "another SMS backend."
             )
 
-        account_sid: Optional[str] = getattr(settings, 'TWILIO_ACCOUNT_SID')
+        account_sid: Optional[str] = kwargs.pop(
+            'username', getattr(settings, 'TWILIO_ACCOUNT_SID')
+        )
         if not account_sid and not self.fail_silently:
             raise ImproperlyConfigured(
                 "You're using the SMS backend "
@@ -36,7 +38,9 @@ class SmsBackend(BaseSmsBackend):
                 "setting 'TWILIO_ACCOUNT_SID' set."
             )
 
-        auth_token: Optional[str] = getattr(settings, 'TWILIO_AUTH_TOKEN')
+        auth_token: Optional[str] = kwargs.pop(
+            'password', getattr(settings, 'TWILIO_AUTH_TOKEN')
+        )
         if not auth_token and not self.fail_silently:
             raise ImproperlyConfigured(
                 "You're using the SMS backend "
@@ -46,7 +50,7 @@ class SmsBackend(BaseSmsBackend):
 
         self.client = None
         if HAS_TWILIO:
-            self.client = Client(account_sid, auth_token)
+            self.client = Client(account_sid, auth_token, **kwargs)
 
     def send_messages(self, messages: List[Message]) -> int:
         if not self.client:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -211,6 +211,26 @@ class MessageBirdBackendTests(BaseSmsBackendTests, SimpleTestCase):
             ['+441134960000'],
             'Here is the message'
         )
+        self.assertEqual(connection.client.access_key, 'fake_access_key')  # type: ignore
+
+    def test_send_messages_explicit_backend(self) -> None:
+        """Test send_messages with the MessageBird backend with explicit parameters."""
+        with sms.get_connection(  # type: ignore
+            access_key='another_access_key',
+        ) as connection:
+            connection.client.message_create = MagicMock()  # type: ignore
+            message = Message(
+                'Here is the message',
+                '+12065550100',
+                ['+441134960000'],
+                connection=connection
+            ).send()
+            connection.client.message_create.assert_called_with(  # type: ignore
+                '+12065550100',
+                ['+441134960000'],
+                'Here is the message'
+            )
+            self.assertEqual(connection.client.access_key, 'another_access_key')  # type: ignore
 
 
 class TwilioBackendTests(BaseSmsBackendTests, SimpleTestCase):
@@ -244,6 +264,29 @@ class TwilioBackendTests(BaseSmsBackendTests, SimpleTestCase):
             from_='+12065550100',
             body='Here is the message'
         )
+        self.assertEqual(connection.client.username, 'fake_account_sid')  # type: ignore
+        self.assertEqual(connection.client.password, 'fake_auth_token')  # type: ignore
+
+    def test_send_messages_explicit_backend(self) -> None:
+        """Test send_messages with the Twilio backend with explicit parameters."""
+        with sms.get_connection(  # type: ignore
+            username='another_account_sid',
+            password='another_auth_token',
+        ) as connection:
+            connection.client.messages.create = MagicMock()  # type: ignore
+            message = Message(
+                'Here is the message',
+                '+12065550100',
+                ['+441134960000'],
+                connection=connection
+            ).send()
+            connection.client.messages.create.assert_called_with(  # type: ignore
+                to='+441134960000',
+                from_='+12065550100',
+                body='Here is the message'
+            )
+            self.assertEqual(connection.client.username, 'another_account_sid')  # type: ignore
+            self.assertEqual(connection.client.password, 'another_auth_token')  # type: ignore
 
 
 class SignalTests(SimpleTestCase):


### PR DESCRIPTION
Sometimes different backends or different backend credentials are necessary to be used simultaneously in one instance of the server, so we need to have an option to transfer parameters from the get_connection() call immediately to the backend-specific client constructor.