### PR TITLE
Added support for python3.11, django4.0 and django4.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,10 +10,10 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 
 def long_description() -> str:
@@ -48,6 +48,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
     packages=find_packages(exclude=['tests', 'tests.*']),
     include_package_data=True,

--- a/sms/__init__.py
+++ b/sms/__init__.py
@@ -1,7 +1,7 @@
 """
 Tools for sending text messages.
 """
-from typing import Type, Union, List, Optional
+from typing import List, Optional, Type, Union
 
 from django.conf import settings  # type: ignore
 from django.utils.module_loading import import_string  # type: ignore
@@ -9,14 +9,13 @@ from django.utils.module_loading import import_string  # type: ignore
 from sms.backends.base import BaseSmsBackend
 from sms.message import Message
 
-
 __all__ = [
     'Message', 'get_connection', 'send_sms'
 ]
 
 
 def get_connection(
-    backend: str = None,
+    backend: Optional[str] = None,
     fail_silently: bool = False,
     **kwargs
 ) -> Type[BaseSmsBackend]:

--- a/sms/backends/filebased.py
+++ b/sms/backends/filebased.py
@@ -3,7 +3,6 @@ SMS backend that writes messages to a file.
 """
 import datetime
 import os
-
 from typing import Optional
 
 from django.conf import settings  # type: ignore
@@ -14,6 +13,8 @@ from sms.message import Message
 
 
 class SmsBackend(BaseSmsBackend):
+    file_path: str
+
     def __init__(
         self,
         *args,
@@ -21,11 +22,15 @@ class SmsBackend(BaseSmsBackend):
         **kwargs
     ) -> None:
         self._fname: Optional[str] = None
-        if file_path is not None:
-            self.file_path = file_path
-        else:
-            self.file_path = getattr(settings, 'SMS_FILE_PATH', None)
-        self.file_path = os.path.abspath(self.file_path)
+        if not file_path:
+            file_path = getattr(settings, 'SMS_FILE_PATH', None)
+        if not file_path:
+            raise ImproperlyConfigured((
+                'Missin path for saving text messages'
+            ))
+        self.file_path = file_path
+
+        self.file_path: str = os.path.abspath(self.file_path)
         try:
             os.makedirs(self.file_path, exist_ok=True)
         except FileExistsError:

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,11 @@
 [tox]
 envlist =
-    py3{6,7,8,9,10}-django22
-    py3{6,7,8,9,10}-django31
-    py3{6,7,8,9,10}-django32
-    py3{6,7,8,9,10}-master
+    py3{6,7,8,9,10,11}-django22
+    py3{6,7,8,9,10,11}-django31
+    py3{6,7,8,9,10,11}-django32
+    py3{6,7,8,9,10,11}-django40
+    py3{6,7,8,9,10,11}-django41
+    py3{6,7,8,9,10,11}-master
     mypy
     pep8
 
@@ -23,6 +25,8 @@ deps=
     django22: Django==2.2.*
     django31: Django==3.1.*
     django32: Django==3.2.*
+    django40: Django==4.0.*
+    django41: Django==4.1.*
     django-master: https://github.com/django/django/archive/master.tar.gz
 
 [testenv:pep8]


### PR DESCRIPTION
I've made the same you've done in https://github.com/roaldnefs/django-sms/commit/cf445bc441066bbe97eeb0eac48faad7ad886e93 and added support for multiple django versions.

I've also fixed a few errors that used to appear during CI tests. 
I've also refactored the init method on SmsBackend in the same time as it could have raised other errors (empty string in `os.path.abspath`)