### PR TITLE
Fix coverage report in when running tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ envlist =
 
 [testenv]
 commands =
-    {envpython} -m coverage run setup.py test
+    {envpython} -m coverage run --source=sms setup.py test
     {envpython} -m coverage report
     {envpython} -m coverage html
     {envpython} -m mypy --config-file=tox.ini sms tests
@@ -35,8 +35,7 @@ commands =
 deps=
     flake8
 
-[coverage:run]
-include = sms*
+[coverage]
 
 [mypy]
 


### PR DESCRIPTION
Fix the coverage report by specifying the source when running coverage using tox.

Closes #31.